### PR TITLE
switch to tricks.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.0.1"
 ExproniconLite = "55351af7-c7e9-48d6-89ff-24e801d99491"
 SumTypes = "8e1ec7a9-0e02-4297-b0fe-6433085c89f2"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
+Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [compat]
 Aqua = "0.8"

--- a/src/BehaviorDispatch.jl
+++ b/src/BehaviorDispatch.jl
@@ -18,7 +18,7 @@ DuckType that implemented the behavior and calls the method on that DuckType.
 """
 @inline function dispatch_behavior(
         behavior::Type{Behavior{F, S}}, args...; kwargs...) where {F, S}
-    DuckT = get_specific_duck_type(fieldtypes(S), args)
+    DuckT = get_specific_duck_type(static_fieldtypes(S), args)
     OGDuckT = find_original_duck_type(DuckT, behavior)
     if isnothing(OGDuckT)
         error("No fitting iterate method found for $DuckT")

--- a/src/DuckDispatch.jl
+++ b/src/DuckDispatch.jl
@@ -21,6 +21,7 @@ end
 using TestItems: @testitem
 using SumTypes: @sum_type, @cases
 using ExproniconLite: JLFunction, JLStruct, is_function, codegen_ast
+using Tricks: static_fieldtypes, static_methods, static_hasmethod
 
 include("Utils.jl")
 include("Types.jl")

--- a/src/TypeUtils.jl
+++ b/src/TypeUtils.jl
@@ -155,7 +155,7 @@ end
 
 @generated function rewrap_where_this(
         ::Type{T}, ::Type{D}, args::Tuple) where {D <: DuckType, T <: Tuple}
-    fields = fieldtypes(T)
+    fields = static_fieldtypes(T)
     duck_types = tuple((D for _ in fields)...)
     return :(tuple_map(wrap_if_this, $fields, $duck_types, args))
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -9,10 +9,10 @@ Returns a tuple of the types in a Union type.
 end
 
 function make_f_calls(f, tuples)
-    first_tuple_types = fieldtypes(tuples[1])
+    first_tuple_types = static_fieldtypes(tuples[1])
     tuple_lengths = length(first_tuple_types)
     number_of_tuples = length(tuples)
-    @assert all(length(fieldtypes(t)) == tuple_lengths for t in tuples) "all tuples must be same length"
+    @assert all(length(static_fieldtypes(t)) == tuple_lengths for t in tuples) "all tuples must be same length"
     f_calls = [:(f($(
                    (:(tuples[$j][$i]) for j in 1:number_of_tuples)...)
                )


### PR DESCRIPTION
Use tricks.jl to completely eliminate overhead for `hasmethod` types and almost all overhead for `methods` types