### PR TITLE
switch to static_method_count

### DIFF
--- a/src/DuckDispatch.jl
+++ b/src/DuckDispatch.jl
@@ -21,7 +21,7 @@ end
 using TestItems: @testitem
 using SumTypes: @sum_type, @cases
 using ExproniconLite: JLFunction, JLStruct, is_function, codegen_ast
-using Tricks: static_fieldtypes, static_methods, static_hasmethod
+using Tricks: static_fieldtypes, static_hasmethod, static_method_count
 
 include("Utils.jl")
 include("Types.jl")

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -75,7 +75,7 @@ end
     replaced = replace_this(get_signature(B), Data)
     func_type = get_func_type(B)
     checks = :($static_hasmethod($(func_type.instance), $replaced) ||
-               !isempty(static_methods($(func_type.instance), $replaced)))
+               static_method_count($(func_type.instance), $replaced) > 0)
     return checks
 end
 


### PR DESCRIPTION
Instead of `!isempty(methods(...))` use `static_method_count(...) > 0`. Totally removes excess allocations!